### PR TITLE
Fix script not deleting intermediary audio/video files after muxing each file

### DIFF
--- a/fps_conform.sh
+++ b/fps_conform.sh
@@ -190,8 +190,8 @@ for INPUT_FILE in "$FOLDER"/*.mkv; do
     MUX "$INPUT_FILE"
 
     # Delete intermediary files to save space
-    rm -f "$OUTPUT_VID/$INPUT_FILE"
-    rm -f "$OUTPUT_AUD/$INPUT_FILE"
+    rm -f "$OUTPUT_VID/$OUTPUT_FILE"
+    rm -f "$OUTPUT_AUD/$OUTPUT_FILE"
   fi
 done
 


### PR DESCRIPTION
It's not obvious unless you are looking at the temp folder contents while the script is going since the script will delete whole temp folder at the end anyway, but this mistake caused the disk to run out of space for me once when it wouldn't have otherwise.